### PR TITLE
Add Tides Controller and Tests

### DIFF
--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/TidesController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/TidesController.java
@@ -2,8 +2,43 @@ package edu.ucsb.cs156.spring.backenddemo.controllers;
 
 import org.springframework.web.bind.annotation.RestController;
 
+import edu.ucsb.cs156.spring.backenddemo.services.TidesQueryService;
+import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name="Tides info from https://api.tidesandcurrents.noaa.gov/api/prod/")
+@Slf4j
 @RestController
+@RequestMapping("/api/tides")
 public class TidesController {
+
+    ObjectMapper mapper = new ObjectMapper();
+
+    @Autowired
+    TidesQueryService tidesQueryService;
+
+    @Operation(summary = "Get water level for date range, in local time.", description = "")
+    @GetMapping("/get")
+    public ResponseEntity<String> getTides(
+        @Parameter(name="beginDate", description="begin date in format yyyymmdd", example="20210501") @RequestParam String beginDate,
+        @Parameter(name="endDate", description="end date in format yyyymmdd", example="20210502") @RequestParam String endDate,
+        @Parameter(name="station", description="station id", example="9411340") @RequestParam String station
+    ) throws JsonProcessingException {
+        log.info("getTides: beginDate={} endDate={} station={}", beginDate, endDate, station);
+        String result = tidesQueryService.getJSON(beginDate, endDate, station);
+        return ResponseEntity.ok().body(result);
+    }
 
 }

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/TidesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/TidesControllerTests.java
@@ -1,0 +1,60 @@
+package edu.ucsb.cs156.spring.backenddemo.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import edu.ucsb.cs156.spring.backenddemo.services.TidesQueryService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpHeaders;
+
+
+@WebMvcTest(value = TidesController.class)
+public class TidesControllerTests {
+    private ObjectMapper mapper = new ObjectMapper();
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    TidesQueryService mockTidesQueryService;
+
+
+    @Test
+    public void test_getTides() throws Exception {
+
+    String fakeJsonResult="{ \"fake\" : \"result\" }";
+    String beginDate = "20210501";
+    String endDate = "20210502";
+    String station = "9411340";
+    when(mockTidesQueryService.getJSON(eq(beginDate),eq(endDate),eq(station))).thenReturn(fakeJsonResult);
+
+    String url = String.format("/api/tides/get?beginDate=%s&endDate=%s&station=%s",beginDate,endDate,station);
+
+    MvcResult response = mockMvc
+        .perform( get(url).contentType("application/json"))
+        .andExpect(status().isOk()).andReturn();
+
+    String responseString = response.getResponse().getContentAsString();
+
+    assertEquals(fakeJsonResult, responseString);
+    }
+}


### PR DESCRIPTION
In this PR, we add an endpoint `/api/zipcode/get` that can be used to get information about tides.

http://team01-brycewangg-dev.dokku-06.cs.ucsb.edu/swagger-ui/index.html

Closes #13 